### PR TITLE
Additional support for python programming language

### DIFF
--- a/apps/kiss/resources/index.jade
+++ b/apps/kiss/resources/index.jade
@@ -174,18 +174,18 @@ block view-content
                 th(colspan="3")
                   | {{project.name}}
 
-              tr.cursor-pointer(ng-if='selected_project === project' ng-class='{active: selected_file, info: !selected_file}')
+              tr.cursor-pointer(ng-if='selected_project.parameters.language === "C" && selected_project === project' ng-class='{active: selected_file, info: !selected_file}')
                 th
                 th(colspan="2")
                   | Include Files
-              tr.cursor-pointer(ng-if='selected_project === project' ng-repeat = 'file in project_resource.include_files' ng-class='{active: selected_file && selected_file != file, info: !selected_file || selected_file === file}' ng-click='select_file(file, "include")')
+              tr.cursor-pointer(ng-if='selected_project.parameters.language === "C" && selected_project === project' ng-repeat = 'file in project_resource.include_files' ng-class='{active: selected_file && selected_file != file, info: !selected_file || selected_file === file}' ng-click='select_file(file, "include")')
                 td
                 td
                 td
                   i.fa.fa-file-o
                   |  
                   | {{file.name}}
-              tr.cursor-pointer(ng-if='selected_project === project' ng-class='{active: selected_file, info: !selected_file}' ng-click='show_add_include_file_modal()')
+              tr.cursor-pointer(ng-if='selected_project.parameters.language === "C" && selected_project === project' ng-class='{active: selected_file, info: !selected_file}' ng-click='show_add_include_file_modal()')
                  td
                  td
                  td

--- a/apps/kiss/resources/index.jade
+++ b/apps/kiss/resources/index.jade
@@ -247,7 +247,7 @@ block view-content
                 option(value='C') C
                 option(value='Python') Python
               label(for='sourceFileName') Source file name
-              input#sourceFileName.form-control(type='text' value='main.c')
+              input#sourceFileName.form-control(type='text' value='main.c' disabled='disabled')
 
         .modal-footer
           button.btn.btn-default(ng-click='hide_add_project_modal()') Cancel

--- a/apps/kiss/resources/kiss-view-controller.coffee
+++ b/apps/kiss/resources/kiss-view-controller.coffee
@@ -270,11 +270,17 @@ exports.controller = (
               $scope.select_project $scope.selected_project
 
   $scope.show_add_source_file_modal = ->
+
+    language_array = [ '.c' ]
+
+    if $scope.project_resource.parameters.language == 'Python'
+      language_array = [ '.py' ]
+
     FilenameModalFactory.open(
       'Create New Source File'
       'Choose a filename:'
       'Filename'
-      [ '.c', '.py' ]
+      language_array
       'Create')
       .then (data) ->
         if $scope.ws? and $scope.project_resource?


### PR DESCRIPTION
- [x] passing language type to compile.cofee
- [x] choose the compile environment based on #1
- [x] force main.py as a starting filename (de-activate entry box) if they choose python (I assume main.py contains the entry point for now)
- [x] hide includes section in python
- [x] avoid ability to mix .py and .c files in projects

Notes:
I had to resort to reading in the `.json` file to get the project language at compile time. Not the most elegant solution, but I couldn't find another way. 
